### PR TITLE
🐛 fix elapsed time display for sounds longer than 1 hour

### DIFF
--- a/BotSoundboardFront/BotSoundboardFront/src/app/app.module.ts
+++ b/BotSoundboardFront/BotSoundboardFront/src/app/app.module.ts
@@ -49,6 +49,7 @@ import { LoginComponent } from './login/login.component';
 import { ToastrModule } from 'ngx-toastr';
 import { CustomToast } from './snackbars/custom-toast/custom-toast';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { FormatTimePipe } from './pipes/format-time.pipe';
 
 
 
@@ -85,7 +86,8 @@ const config: SocketIoConfig = {
     RenameModalComponent,
     SettingsModalComponent,
     BlindTestModalComponent,
-    CustomToast
+    CustomToast,
+    FormatTimePipe
   ],
   imports: [AngularSplitModule,
     MatMenuModule,

--- a/BotSoundboardFront/BotSoundboardFront/src/app/pipes/format-time.pipe.ts
+++ b/BotSoundboardFront/BotSoundboardFront/src/app/pipes/format-time.pipe.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'formatTime'
+})
+export class FormatTimePipe implements PipeTransform {
+  transform(milliseconds: number, format: string): string {
+    const totalSeconds = Math.floor(milliseconds / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const pad = (num: number) => String(num).padStart(2, '0');
+
+    if (format === 'hh:mm:ss') {
+      return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    return `${pad(minutes)}:${pad(seconds)}`;
+  }
+}

--- a/BotSoundboardFront/BotSoundboardFront/src/app/player/sound-timer/sound-timer.component.html
+++ b/BotSoundboardFront/BotSoundboardFront/src/app/player/sound-timer/sound-timer.component.html
@@ -1,8 +1,7 @@
-<span [ngStyle]="{visibility: soundTime  === 0 ? 'hidden' : 'visible'}" class="timeText">{{ elapsedTime | date:
-    'mm:ss' }}</span>
+<span [ngStyle]="{visibility: soundTime  === 0 ? 'hidden' : 'visible'}" class="timeText">{{ elapsedTime | formatTime: utils.getFormattedTime(moreThanAnHour) }}</span>
 <mat-slider [min]="0" [max]="1" step="0.001" id="slider">
     <input matSliderThumb [(ngModel)]="progress" (change)="progressChanged($event, soundTime)">
 </mat-slider>
 <span [ngStyle]="{ visibility: utils.isTimeVisible(soundTime) }" class="timeText">
-    {{ soundTime | date: utils.getFormattedTime(moreThanAnHour) }}
-  </span>
+    {{ soundTime | formatTime: utils.getFormattedTime(moreThanAnHour) }}
+</span>

--- a/BotSoundboardFront/BotSoundboardFront/src/app/player/sound-timer/sound-timer.component.ts
+++ b/BotSoundboardFront/BotSoundboardFront/src/app/player/sound-timer/sound-timer.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Sound } from 'src/app/declarations';
 import { SocketService } from 'src/services/socket/socket.service';
 import { UtilsService } from 'src/services/utils/utils.service';
+import { FormatTimePipe } from 'src/app/pipes/format-time.pipe';
 
 @Component({
   selector: 'app-sound-timer',


### PR DESCRIPTION
- Add custom FormatTimePipe for proper time formatting
- Replace Angular date pipe with custom formatting logic
- Correctly display hh:mm:ss format when sound duration > 1 hour